### PR TITLE
Scalar, SDL Compiler, Deprecated fields

### DIFF
--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaDefinitionBlock.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaDefinitionBlock.scala
@@ -8,6 +8,7 @@
 
 package io.github.dexclaimation.soda.schema
 
+import sangria.execution.FieldTag
 import sangria.schema.{Action, Argument, Context, Field, IDType, OutputType, PossibleInterface, ValidOutType}
 
 import scala.collection.mutable
@@ -20,11 +21,11 @@ class SodaDefinitionBlock[Ctx, Val: ClassTag] {
   /**
    * Added a field from properties
    *
-   * @param name        Name of the property field.
-   * @param fieldType   The GraphQL Type of that field.
-   * @param desc Additional descriptions.
-   * @param args        Required arguments from the field.
-   * @param of          Getter of the field
+   * @param name      Name of the property field.
+   * @param fieldType The GraphQL Type of that field.
+   * @param desc      Additional descriptions.
+   * @param args      Required arguments from the field.
+   * @param of        Getter of the field
    */
   def prop[Out, Res](
     name: String,
@@ -35,9 +36,7 @@ class SodaDefinitionBlock[Ctx, Val: ClassTag] {
     implicit ev: ValidOutType[Res, Out]
   ): Unit = {
     typedefs.addOne(
-      Field(
-        name = name,
-        fieldType = fieldType,
+      Field(name, fieldType,
         description = if (desc.isEmpty) None else Some(desc),
         arguments = Nil,
         resolve = c => of(c.value)
@@ -51,9 +50,7 @@ class SodaDefinitionBlock[Ctx, Val: ClassTag] {
     desc: String = "",
     of: Val => Action[Ctx, Res]
   )(implicit ev: ValidOutType[Res, String]): Unit =
-    prop[String, Res](
-      name = name,
-      fieldType = IDType,
+    prop[String, Res](name, IDType,
       desc = desc,
       of = of
     )(ev)
@@ -61,25 +58,27 @@ class SodaDefinitionBlock[Ctx, Val: ClassTag] {
   /**
    * Added a field either from a properties or computed
    *
-   * @param name        Name of the property field.
-   * @param fieldType   The GraphQL Type of that field.
-   * @param desc Additional descriptions.
-   * @param args        Required arguments from the field.
-   * @param resolve     Compute or resolve the field
+   * @param name      Name of the property field.
+   * @param fieldType The GraphQL Type of that field.
+   * @param desc      Additional descriptions.
+   * @param args      Required arguments from the field.
+   * @param resolve   Compute or resolve the field
    */
   def field[Out, Res](
     name: String,
     fieldType: OutputType[Out],
     desc: String = "",
     args: List[Argument[_]] = Nil,
+    deprecated: Option[String] = None,
+    tags: List[FieldTag] = Nil,
   )(resolve: Context[Ctx, Val] => Action[Ctx, Res])
     (implicit ev: ValidOutType[Res, Out]): Unit = {
     typedefs.addOne(
-      Field(
-        name = name,
-        fieldType = fieldType,
+      Field(name, fieldType,
         description = if (desc.isEmpty) None else Some(desc),
         arguments = args,
+        deprecationReason = deprecated,
+        tags = tags,
         resolve = c => resolve(c)
       )
     )

--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaEnumType.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaEnumType.scala
@@ -29,7 +29,7 @@ abstract class SodaEnumType[T](name: String) {
    */
   lazy val t: EnumType[T] = EnumType(
     name = name,
-    description = if (desc == "") None else Some(desc),
+    description = if (desc.isEmpty) None else Some(desc),
     values = members
   )
 }

--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaInputType.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaInputType.scala
@@ -36,7 +36,7 @@ abstract class SodaInputType[Val](name: String) {
     val fields = __block.typedefs.toList
     InputObjectType(
       name = name,
-      description = if (desc == "") None else Some(desc),
+      description = if (desc.isEmpty) None else Some(desc),
       fieldsFn = () => fields,
       astDirectives = Vector.empty,
       astNodes = Vector.empty

--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaInputType.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaInputType.scala
@@ -20,6 +20,8 @@ import sangria.schema.InputObjectType
  * @tparam Val Value paired for this Object (*best to implement this on a case class's companion object)
  */
 abstract class SodaInputType[Val](name: String) {
+
+  /** Definition Block */
   type Def = SodaInputBlock[Val] => Unit
 
   private val __block = new SodaInputBlock[Val]()

--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaInterfaceType.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaInterfaceType.scala
@@ -25,6 +25,8 @@ import scala.reflect.ClassTag
  * @tparam Val Value paired for this Interface (*best to implement this on a case class's companion object)
  */
 abstract class SodaInterfaceType[Ctx, Val: ClassTag](name: String) {
+
+  /** Definition Block */
   type Def = SodaDefinitionBlock[Ctx, Val] => Unit
 
   private val __block = new SodaDefinitionBlock[Ctx, Val]

--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaMutation.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaMutation.scala
@@ -19,6 +19,8 @@ import scala.reflect.ClassTag
  */
 abstract class SodaMutation[Ctx, Val: ClassTag] {
   private val __block = new SodaRootBlock[Ctx, Val]
+
+  /** Definition Block */
   type Def = SodaRootBlock[Ctx, Val] => Unit
 
   def definition: Def

--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaObjectType.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaObjectType.scala
@@ -24,6 +24,8 @@ import scala.reflect.ClassTag
  * @tparam Val Value paired for this Object (*best to implement this on a case class's companion object)
  */
 abstract class SodaObjectType[Ctx, Val: ClassTag](name: String) {
+
+  /** Definition block */
   type Def = SodaDefinitionBlock[Ctx, Val] => Unit
 
   private val __block = new SodaDefinitionBlock[Ctx, Val]

--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaObjectType.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaObjectType.scala
@@ -39,7 +39,7 @@ abstract class SodaObjectType[Ctx, Val: ClassTag](name: String) {
     definition(__block)
     ObjectType(
       name = name,
-      description = if (desc == "") None else Some(desc),
+      description = if (desc.isEmpty) None else Some(desc),
       fieldsFn = () => __block.typedefs.toList,
       interfaces = __block.interfaces.map(_.interfaceType).toList,
       instanceCheck = defaultInstanceCheck,

--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaQuery.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaQuery.scala
@@ -19,6 +19,8 @@ import scala.reflect.ClassTag
  */
 abstract class SodaQuery[Ctx, Val: ClassTag] {
   private val __block = new SodaRootBlock[Ctx, Val]
+
+  /** Definition Block */
   type Def = SodaRootBlock[Ctx, Val] => Unit
 
   def definition: Def

--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaRootBlock.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaRootBlock.scala
@@ -7,6 +7,7 @@
 
 package io.github.dexclaimation.soda.schema
 
+import sangria.execution.FieldTag
 import sangria.schema.{Action, Argument, Context, Field, IDType, OutputType, ValidOutType}
 
 import scala.collection.mutable
@@ -65,11 +66,15 @@ class SodaRootBlock[Ctx, Val: ClassTag] {
     fieldType: OutputType[Out],
     desc: String = "",
     args: List[Argument[_]] = Nil,
+    deprecated: Option[String] = None,
+    tags: List[FieldTag] = Nil,
   )(resolve: Context[Ctx, Val] => Action[Ctx, Res])
     (implicit ev: ValidOutType[Res, Out]): Unit = {
     fields.addOne(
       Field(name, fieldType, if (desc.isEmpty) None else Some(desc), args,
-        resolve = c => resolve(c)
+        deprecationReason = deprecated,
+        tags = tags,
+        resolve = ctx => resolve(ctx)
       )
     )
   }

--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaScalar.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaScalar.scala
@@ -1,0 +1,41 @@
+//
+//  SodaScalar.scala
+//  soda
+//
+//  Created by d-exclaimation on 12:51 AM.
+//
+
+package io.github.dexclaimation.soda.schema
+
+import sangria.ast
+import sangria.marshalling.MarshallerCapability
+import sangria.schema.ScalarType
+import sangria.validation.Violation
+
+abstract class SodaScalar[Val](name: String) {
+
+  /** Serialize scalar to the proper JSON Serialized form */
+  type Serializer = (Val, Set[MarshallerCapability]) => Any
+
+  /** Parse given input to either the Value or a violation */
+  type Parser[Input] = Input => Either[Violation, Val]
+
+  def desc: String = ""
+
+  def serialize: Serializer
+
+  def parseValue: Parser[Any]
+
+  def parseLiteral: Parser[ast.Value]
+
+  /**
+   * Sangria Scalar Type derivation
+   */
+  lazy val t: ScalarType[Val] = ScalarType[Val](
+    name = name,
+    description = if (desc.isEmpty) None else Some(desc),
+    coerceInput = parseLiteral,
+    coerceUserInput = parseValue,
+    coerceOutput = serialize
+  )
+}

--- a/src/main/scala/io/github/dexclaimation/soda/schema/SodaSubscription.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/schema/SodaSubscription.scala
@@ -19,6 +19,8 @@ import scala.reflect.ClassTag
  */
 abstract class SodaSubscription[Ctx, Val: ClassTag] {
   private val __block = new SodaRootBlock[Ctx, Val]
+
+  /** Definition Block */
   type Def = SodaRootBlock[Ctx, Val] => Unit
 
   def definition: Def

--- a/src/main/scala/io/github/dexclaimation/soda/utils/Artifacts.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/utils/Artifacts.scala
@@ -1,0 +1,56 @@
+//
+//  Artifacts.scala
+//  soda
+//
+//  Created by d-exclaimation on 12:36 AM.
+//
+
+package io.github.dexclaimation.soda.utils
+
+import sangria.renderer.SchemaRenderer
+import sangria.schema.Schema
+
+import java.io.{File, PrintWriter}
+import scala.reflect.ClassTag
+
+object Artifacts {
+  /**
+   * Artifact compiler
+   *
+   * @param schema The Sangria schema to be compiled into.
+   * @param path   The resulting path.
+   */
+  def compile[Ctx, Val: ClassTag](
+    schema: Schema[Ctx, Val],
+    path: String = "./src/main/resources/artifacts/schema.graphql"
+  ): Unit = {
+    val compiled = SchemaRenderer.renderSchema(schema)
+    val target = new File(path)
+    makeIfNotExist(target)
+    compileFile(target, compiled)
+  }
+
+  /**
+   * Make the file if it doesn't exist yet
+   *
+   * @param file The file to be written.
+   */
+  private def makeIfNotExist(file: File): Unit = {
+    if (!file.exists()) {
+      println(file.getParentFile.mkdirs())
+      println(file.createNewFile())
+    }
+  }
+
+  /**
+   * Compile the file or overwrite the new file
+   *
+   * @param file        the target File.
+   * @param compilation The compilation result.
+   */
+  private def compileFile(file: File, compilation: String): Unit = {
+    val writer = new PrintWriter(file)
+    writer.write(compilation)
+    writer.close()
+  }
+}

--- a/src/main/scala/io/github/dexclaimation/soda/utils/SchemaDefinition.scala
+++ b/src/main/scala/io/github/dexclaimation/soda/utils/SchemaDefinition.scala
@@ -51,4 +51,23 @@ object SchemaDefinition {
       subscription = if (SubscriptionType.fields.isEmpty) None else Some(SubscriptionType)
     )
   }
+
+
+  /**
+   * Make schema and compile artifacts into the resource folder
+   * Default file path: "src/main/resources/artifacts/schema.graphql"
+   *
+   * @param fields The schema fields to be composed into a single schema.
+   * @param path   The resulting path.
+   * @tparam C The context type.
+   * @tparam T The root value type.
+   * @return The schema and perform side effect writing the SDL into "src/main/resources/artifacts/schema.graphql"
+   */
+  def makeSchemaAndArtifacts[C, T: ClassTag](
+    fields: Seq[SodaSchemaField[C, T]], path: String = "./src/main/resources/artifacts/schema.graphql"
+  ): Schema[C, T] = {
+    val schema = makeSchema[C, T](fields: _*)
+    Artifacts.compile(schema, path)
+    schema
+  }
 }


### PR DESCRIPTION
## Changes

- Deprecated field capabilities for `SchemaDefinitionBlock`'s `field` method.
- Code to SDL Compiler.
- `makeSchemaAndArtifacts` utility function
- `SodaScalar` type